### PR TITLE
fix: swap-cla-action-to-maintained-fork

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,4 +24,4 @@ jobs:
           path-to-document: "https://github.com/Staffbase/custom-widgets-examples/blob/main/CLA.md"
           # branch should not be protected
           branch: "signatures"
-          allowlist: "Ninerian,m-seidel,cornelius-behrend,boehmmic,staffbot,dependabot,Copilot,noreply@anthropic.com,noreply@opencode.ai,copilot@noreply.github.com,*[bot]"
+          allowlist: Ninerian,m-seidel,cornelius-behrend,boehmmic,staffbot,dependabot,Copilot,noreply@anthropic.com,noreply@opencode.ai,copilot@noreply.github.com,*[bot]

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,21 +7,21 @@ on:
   issue_comment:
     types: [created]
   pull_request:
-    types: [opened,closed,synchronize]
-    
+    types: [opened, closed, synchronize]
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: iainmcgin/cla-github-action@3e58ace6af840f66fcd80f68c08d76559140df5e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.OSS_CONTRIBUTOR_LICENSE_AGREEMENT }}
-        with: 
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/Staffbase/custom-widgets-examples/blob/main/CLA.md'
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/Staffbase/custom-widgets-examples/blob/main/CLA.md"
           # branch should not be protected
-          branch: 'signatures'
-          allowlist: Ninerian,m-seidel,cornelius-behrend,boehmmic,staffbot,dependabot,Copilot
+          branch: "signatures"
+          allowlist: "Ninerian,m-seidel,cornelius-behrend,boehmmic,staffbot,dependabot,Copilot,noreply@anthropic.com,noreply@opencode.ai,copilot@noreply.github.com,*[bot]"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,4 +24,4 @@ jobs:
           path-to-document: "https://github.com/Staffbase/custom-widgets-examples/blob/main/CLA.md"
           # branch should not be protected
           branch: "signatures"
-          allowlist: Ninerian,m-seidel,cornelius-behrend,boehmmic,staffbot,dependabot,Copilot,noreply@anthropic.com,noreply@opencode.ai,copilot@noreply.github.com,*[bot]
+          allowlist: staffbot,dependabot,Copilot,noreply@anthropic.com,noreply@opencode.ai,copilot@noreply.github.com,*[bot]


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency

### Description
DEVS-1238
- `contributor-assistant/github-action` is archived/read-only. Updating it to maintained fork `iainmcgin/cla-github-action`. Also, updated the allowlist to include the mandated AI trailer emails.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](https://github.com/Staffbase/custom-widgets-examples/blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
