### PR TITLE
chore(backstage): remove explicit owner from custom-widget-examples catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,4 +11,3 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: need-for-speed-devs


### PR DESCRIPTION
Backstage cleanup: remove stale explicit ownership from the component catalog metadata.

Why:
- This repository still had `spec.owner: need-for-speed-devs` in `catalog-info.yaml`.
- After team/domain ownership updates, explicit owner fields can become outdated and misleading in Backstage.

What this changes:
- Removes `spec.owner` from `catalog-info.yaml` for the `custom-widget-examples` component.

Result:
- Avoids stale ownership metadata in Backstage and allows ownership to be derived from `CODEOWNERS`.