### PR TITLE
fix: point catalog-info project-slug at this repo

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@ metadata:
   name: custom-widget-examples
   description: Some examples how to use the third party widget framework
   annotations:
-    github.com/project-slug: Staffbase/custom-widget-examples
+    github.com/project-slug: Staffbase/custom-widgets-examples
   tags:
     - widgets
     - typescript


### PR DESCRIPTION
## What
`catalog-info.yaml` had `github.com/project-slug: Staffbase/custom-widget-examples` (singular). That repo does not exist. Changed to `Staffbase/custom-widgets-examples` (this repo).

## Why
Backstage keyed this component to a non-existent repo, so this repo had no catalog entry and tooling joining on the GitHub repo name (Backstage-derived `dim_repository`, security-finding owner resolution) couldn't resolve its owner.

## Review
One line changed; component now resolves to its own repo.