### PR TITLE
ACT-3681: fix brace-expansion GHSA-jxxr-4gwj-5jf2

### DIFF
--- a/samples/weather-forecast/yarn.lock
+++ b/samples/weather-forecast/yarn.lock
@@ -3782,9 +3782,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.6"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation
- [x] Dependency

### Description

Updates the affected `brace-expansion@^5.0.2` lock entry from 5.0.5 to 5.0.6 for [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) and Dependabot alert #157. The safe 1.1.13 line remains unchanged.

Risk: 7.3/10 before testing → 1/10 residual. The affected 5.x entry is not present in the installed graph; the remaining installed 1.x line is already safe.

Validation:

- frozen Yarn install and dependency-graph proof
- bounded 5.0.6 numeric-range cap probe: 1,000,000,000 range limited to 100 results in 2 ms
- production build, lint, and TypeScript checks passed
- 9/10 Jest files and all 18 executed tests passed; the remaining suite is blocked on current main by `@rjsf/mui@6.5.2` importing a missing `@mui/icons-material/Add` JavaScript file from the published 6.5.0 package

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](https://github.com/Staffbase/custom-widgets-examples/blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging

Jira: [ACT-3681](https://mitarbeiterapp.atlassian.net/browse/ACT-3681)



[ACT-3681]: https://mitarbeiterapp.atlassian.net/browse/ACT-3681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ