### PR TITLE
ACT-3682: fix js-yaml GHSA-h67p-54hq-rp68

### DIFF
--- a/samples/weather-forecast/package.json
+++ b/samples/weather-forecast/package.json
@@ -94,8 +94,7 @@
     "jest-util/picomatch": "4.0.4",
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "js-yaml": "4.1.1",
-    "@istanbuljs/load-nyc-config/js-yaml": "3.14.2",
+    "js-yaml": "4.2.0",
     "qs": "6.14.2",
     "on-headers": "1.1.0"
   }

--- a/samples/weather-forecast/yarn.lock
+++ b/samples/weather-forecast/yarn.lock
@@ -5934,18 +5934,10 @@ js-sha3@0.8.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.14.2:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@4.1.1, js-yaml@^3.13.1, js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@4.2.0, js-yaml@^3.13.1, js-yaml@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation
- [x] Dependency

### Description

Updates the weather sample's JS-YAML resolution to 4.2.0 and removes the obsolete vulnerable 3.14.2 lock entry. This covers [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) and Dependabot alerts #170–#171.

Risk: 6.1/10 before testing → 1/10 residual. The installed graph resolves one advisory-safe JS-YAML 4.2.0 line.

Validation:

- frozen Yarn install and dependency-graph proof
- 2,000 repeated merge-alias documents parsed in 61 ms
- production build, lint, and TypeScript checks passed
- 9/10 Jest files and all 18 executed tests passed; the remaining suite is blocked on current main by the published MUI icon package mismatch

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](https://github.com/Staffbase/custom-widgets-examples/blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging

Jira: [ACT-3682](https://mitarbeiterapp.atlassian.net/browse/ACT-3682)



[ACT-3682]: https://mitarbeiterapp.atlassian.net/browse/ACT-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ